### PR TITLE
support for secureTextEntry in the TextInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import DialogInput from 'react-native-dialog-input';
  message               | Message to show in the DialogInput          |   String (OPTIONAL)
  hintInput             | Text hint to show in the TextInput          |   String (OPTIONAL)
  initValueTextInput    | Default value for the TextInput             |   String (OPTIONAL)
- textInputProps        | Additional properties to add to the TextInput in the form:<BR> `textInputProps={{autoCorrect:false}}`  Currently supports:<BR>autoCorrect<BR>autoCapitalize<BR>clearButtonMode<BR>clearTextOnFocus <BR>keyboardType          |    Object (OPTIONAL)
+ textInputProps        | Additional properties to add to the TextInput in the form:<BR> `textInputProps={{autoCorrect:false}}`  Currently supports:<BR>autoCorrect<BR>autoCapitalize<BR>clearButtonMode<BR>clearTextOnFocus<BR>keyboardType<BR>secureTextEntry          |    Object (OPTIONAL)
 modalStyle   | Styles for the blocking view behind the DialogInput             |   Object (OPTIONAL)
 dialogStyle             | Styles for the DialogInput main view                        |   Object (OPTIONAL)
 cancelText             | Replacement text for the Cancel button      |   String (OPTIONAL)

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ class DialogInput extends React.Component{
                   clearButtonMode={(textProps && textProps.clearButtonMode)?textProps.clearButtonMode:'never'}
                   clearTextOnFocus={(textProps && textProps.clearTextOnFocus==true)?textProps.clearTextOnFocus:false}
                   keyboardType={(textProps && textProps.keyboardType)?textProps.keyboardType:'default'}
+                  secureTextEntry={(textProps && textProps.secureTextEntry)?textProps.secureTextEntry:false}
                   autoFocus={true}
                   onKeyPress={() => this.setState({ openning: false })}
                   underlineColorAndroid='transparent'


### PR DESCRIPTION
as the commit suggests, this adds the React Native-standard 'secureTextEntry' prop to the TextInput, which, when true, enables a password-style input.