### PR TITLE
Bug fix: set openning state to false for TextInput onChangeText

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class DialogInput extends React.Component{
                   onKeyPress={() => this.setState({ openning: false })}
                   underlineColorAndroid='transparent'
                   placeholder={hintInput}
-                  onChangeText={(inputModal) => this.setState({inputModal})}
+                  onChangeText={(inputModal) => this.setState({inputModal, openning: false})}
                   value={value}
                   />
               </View>


### PR DESCRIPTION
If `keyboardType` set to 'number-pad' for textInputProps we need to close the modal upon finish.